### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,6 +23,6 @@
     ],
     "context_root": "Neural Networks"
   },
-  "min_instance_version": "6.13.8",
+  "instance_version": "6.15.60",
   "poster": "https://user-images.githubusercontent.com/48245050/182627503-8dab4d23-8c6d-43fc-aea7-14abb4a14d03.png"
 }

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "inference interfaces"
   ],
   "description": "Run 3D Detection and tracking algorithm on pointclouds or pointcloud episodes project",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "inference interfaces"
   ],
   "description": "Run 3D Detection and tracking algorithm on pointclouds or pointcloud episodes project",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "inference interfaces"
   ],
   "description": "Run 3D Detection and tracking algorithm on pointclouds or pointcloud episodes project",
-  "docker_image": "supervisely/base-py-sdk:6.73.394",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,1 @@
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
